### PR TITLE
Minor tweaks to work better on the ESP32

### DIFF
--- a/HMC5883L.cpp
+++ b/HMC5883L.cpp
@@ -120,42 +120,48 @@ MagnetometerScaled HMC5883L::readScaledAxis()
 short HMC5883L::setScale(float gauss)
 {
     uint8_t regValue = 0x00;
-    if(gauss == 0.88)
+
+/* Some of these values; e.g. 1.3 - cause comparison
+ * issues with the compiler that the Arduino IDE uses.
+ */
+#define CLOSEENOUGH(x,y) (fabs(x-y)<0.001)
+
+    if(CLOSEENOUGH(gauss , 0.88))
     {
         regValue = 0x00;
         m_Scale = 0.73;
     }
-    else if(gauss == 1.3)
+    else if(CLOSEENOUGH(gauss , 1.3))
     {
         regValue = 0x01;
         m_Scale = 0.92;
     }
-    else if(gauss == 1.9)
+    else if(CLOSEENOUGH(gauss , 1.9))
     {
         regValue = 0x02;
         m_Scale = 1.22;
     }
-    else if(gauss == 2.5)
+    else if(CLOSEENOUGH(gauss , 2.5))
     {
         regValue = 0x03;
         m_Scale = 1.52;
     }
-    else if(gauss == 4.0)
+    else if(CLOSEENOUGH(gauss , 4.0))
     {
         regValue = 0x04;
         m_Scale = 2.27;
     }
-    else if(gauss == 4.7)
+    else if(CLOSEENOUGH(gauss , 4.7))
     {
         regValue = 0x05;
         m_Scale = 2.56;
     }
-    else if(gauss == 5.6)
+    else if(CLOSEENOUGH(gauss , 5.6))
     {
         regValue = 0x06;
         m_Scale = 3.03;
     }
-    else if(gauss == 8.1)
+    else if(CLOSEENOUGH(gauss , 8.1))
     {
         regValue = 0x07;
         m_Scale = 4.35;

--- a/HMC5883L.cpp
+++ b/HMC5883L.cpp
@@ -26,8 +26,9 @@
 #include <Arduino.h>
 #include "HMC5883L.h"
 
-HMC5883L::HMC5883L()
+HMC5883L::HMC5883L(TwoWire &w)
 {
+    _wire = & w;
     m_Scale = 1;
 }
 
@@ -174,32 +175,32 @@ short HMC5883L::setMeasurementMode(uint8_t mode)
 
 void HMC5883L::write(short address, short data)
 {
-    Wire.beginTransmission(HMC5883L_ADDRESS);
-    Wire.write(address);
-    Wire.write(data);
-    Wire.endTransmission();
+    _wire->beginTransmission(HMC5883L_ADDRESS);
+    _wire->write(address);
+    _wire->write(data);
+    _wire->endTransmission();
 }
 
 uint8_t* HMC5883L::read(short address, short length)
 {
-    Wire.beginTransmission(HMC5883L_ADDRESS);
-    Wire.write(address);
-    Wire.endTransmission();
+    _wire->beginTransmission(HMC5883L_ADDRESS);
+    _wire->write(address);
+    _wire->endTransmission();
 
-    Wire.beginTransmission(HMC5883L_ADDRESS);
-    Wire.requestFrom(HMC5883L_ADDRESS, length);
+    _wire->beginTransmission(HMC5883L_ADDRESS);
+    _wire->requestFrom(HMC5883L_ADDRESS, length);
 
     uint8_t buffer[length];
     
-    if(Wire.available() == length)
+    if(_wire->available() == length)
     {
         for(uint8_t i = 0; i < length; i++)
         {
-            buffer[i] = Wire.read();
+            buffer[i] = _wire->read();
         }
     }
     
-    Wire.endTransmission();
+    _wire->endTransmission();
     return buffer;
 }
 

--- a/HMC5883L.cpp
+++ b/HMC5883L.cpp
@@ -190,18 +190,16 @@ uint8_t* HMC5883L::read(short address, short length)
     _wire->beginTransmission(HMC5883L_ADDRESS);
     _wire->requestFrom(HMC5883L_ADDRESS, length);
 
-    uint8_t buffer[length];
-    
     if(_wire->available() == length)
     {
-        for(uint8_t i = 0; i < length; i++)
+        for(uint8_t i = 0; i < length && i < sizeof(_buffer); i++)
         {
-            buffer[i] = _wire->read();
+            _buffer[i] = _wire->read();
         }
     }
     
     _wire->endTransmission();
-    return buffer;
+    return _buffer;
 }
 
 char* HMC5883L::getErrorText(short errorCode)

--- a/HMC5883L.h
+++ b/HMC5883L.h
@@ -87,6 +87,7 @@ protected:
     private:
     TwoWire * _wire;
     float m_Scale;
+    uint8_t _buffer[16];
 };
 
 #endif

--- a/HMC5883L.h
+++ b/HMC5883L.h
@@ -67,7 +67,8 @@ public:         // used by xadow phone
     int getCompass();
     
 public:
-    HMC5883L();
+    HMC5883L(TwoWire &w = Wire);
+
 
     MagnetometerRaw readRawAxis();
     MagnetometerScaled readScaledAxis();
@@ -84,6 +85,7 @@ protected:
     uint8_t* read(short address, short length);
 
     private:
+    TwoWire * _wire;
     float m_Scale;
 };
 


### PR DESCRIPTION
Allow for the use of a different i2c bus.

Make the comparisons a bit more slack - on the Arduino IDE the exact comparsion with 1.3 would fail (not turned this into a full enum solution).

Move the buffer to the privates; as the compiler on the Arduino IDE no longer accepts this.